### PR TITLE
added test for ini and updated documentation, closes #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,36 @@ an interface to [markdownlint](https://github.com/DavidAnson/markdownlint).
 
 The package reads the configuration from the `.markdownlintrc` file.
 
-For more information see:
+The configuration file can be formatted as [`JSON`](http://json.org/example) or [`INI`](https://en.wikipedia.org/wiki/INI_file).
 
-- [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli#configuration)
-- [markdownlint](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md)
+### JSON Example
+
+```js
+{
+  "default": true,
+  "MD003": { "style": "atx_closed" },
+  "MD007": { "indent": 4 },
+  "no-hard-tabs": false,
+  "MD018": false
+}
+```
+
+### INI Example
+
+```ini
+default=true
+no-hard-tabs=false
+MD018=false
+
+[MD003]
+style=atx_closed
+
+[MD007]
+indent=4
+```
+
+For more information checkout:
+
+* The markdownlint [list of rules](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md)
+* The markdownlint [list of tags](https://github.com/DavidAnson/markdownlint#rules--aliases)
+* The markdownlint-cli [configuration file example](https://github.com/igorshubovych/markdownlint-cli#configuration)

--- a/package.json
+++ b/package.json
@@ -8,6 +8,17 @@
   "scripts": {
     "lint": "coffeelint lib"
   },
+  "author": {
+    "name": "Josa Gesell",
+    "url": "https://github.com/josa42"
+  },
+  "contributors": [
+    {
+      "name": "Garth Braithwaite",
+      "email": "garthdb@gmail.com",
+      "url": "http://garthdb.com"
+    }
+  ],
   "engines": {
     "atom": ">0.50.0"
   },

--- a/spec/linter-node-markdownlint-spec.coffee
+++ b/spec/linter-node-markdownlint-spec.coffee
@@ -40,3 +40,15 @@ describe "Lint markdown", ->
 
             expect(messages[1].text).toEqual("MD041 First line in file should be a top level header")
             expect(messages[1].range).toEqual( [[0, 0], [0, 7]])
+
+  describe "ini format config file .markdownlintrc", ->
+    it "should return 1 error", ->
+
+      waitsForPromise ->
+        atom.workspace.open(path.join(__dirname, 'project_ini', 'bad.md'))
+          .then (editor) -> MarkdownlitProvider.lint(editor)
+          .then (messages) ->
+            expect(messages.length).toEqual(1)
+
+            expect(messages[0].text).toEqual("MD041 First line in file should be a top level header")
+            expect(messages[0].range).toEqual( [[0, 0], [0, 7]])

--- a/spec/project_ini/.markdownlintrc
+++ b/spec/project_ini/.markdownlintrc
@@ -1,0 +1,9 @@
+default=true
+no-hard-tabs=false
+MD018=false
+
+[MD003]
+style=atx_closed
+
+[MD007]
+indent=4

--- a/spec/project_ini/bad.md
+++ b/spec/project_ini/bad.md
@@ -1,0 +1,3 @@
+#bad.md
+
+#This file fails	some rules.


### PR DESCRIPTION
- Update tests to include an example with an `ini` config file.
- Updated documentation to show simple `.markdownlintrc` examples.
- Updated `package.json` to include author and contributors.
