### PR TITLE
updated out of date dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "atom-linter": "^5.0.1",
+    "atom-linter": "^7.0.0",
     "atom-package-deps": "^4.0.1",
-    "markdownlint": "^0.1.1",
+    "markdownlint": "^0.2.0",
     "rc": "^1.1.6"
   },
   "package-deps": [


### PR DESCRIPTION
The big one is `markdownlint` it added a parameter for `MD002` that makes it easier to use on markdown files that will be blog posts and the template is handling the initial `h1`.
